### PR TITLE
Fix: Resolve ImportError in Streamlit app

### DIFF
--- a/grizly_app/__init__.py
+++ b/grizly_app/__init__.py
@@ -1,9 +1,8 @@
 # Package initialization for grizly_app
 
-from . import legal_logic_aligned, response_logic, utils
+from . import response_logic, utils
 
 __all__ = [
-    'legal_logic_aligned',
     'response_logic',
     'utils'
 ]


### PR DESCRIPTION
The Streamlit application was failing to start due to an ImportError for `legal_logic_aligned` in `grizly_app/__init__.py`.

This module appears to be deprecated, as it was found in `archive/deprecated_legal_logic/` and was not used by the main application logic in `grizly_app/app.py` or other key modules.

This commit removes `legal_logic_aligned` from the import statement and the `__all__` list in `grizly_app/__init__.py` to resolve the error.